### PR TITLE
META-INF missing from the jar

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -79,7 +79,7 @@
                 <include name="**/*"/>
             </fileset>
             <fileset dir="${ivyidea.sourcedir}">
-                <include name="/META-INF/**/*"/>
+                <include name="META-INF/**/*"/>
             </fileset>
             <fileset dir="${ivyidea.resourcedir}"/>
         </jar>


### PR DESCRIPTION
Building on GNU/Linux results in a jar without META-INF for me.