### PR TITLE
Don't resolve internal module dependencies each time they are referre…

### DIFF
--- a/src/main/java/org/clarent/ivyidea/ResolveForActiveModuleAction.java
+++ b/src/main/java/org/clarent/ivyidea/ResolveForActiveModuleAction.java
@@ -30,6 +30,7 @@ import org.clarent.ivyidea.intellij.IntellijUtils;
 import org.clarent.ivyidea.intellij.task.IvyIdeaResolveBackgroundTask;
 import org.clarent.ivyidea.ivy.IvyManager;
 import org.clarent.ivyidea.resolve.IntellijDependencyResolver;
+import org.clarent.ivyidea.resolve.ResolveUtil;
 import org.jetbrains.annotations.NotNull;
 
 import java.text.MessageFormat;
@@ -56,7 +57,7 @@ public class ResolveForActiveModuleAction extends AbstractResolveAction {
                     getProgressMonitorThread().setIvy(ivyManager.getIvy(module));
 
                     final IntellijDependencyResolver resolver = new IntellijDependencyResolver(ivyManager);
-                    resolver.resolve(module);
+                    resolver.resolve(module, ResolveUtil.buildExcludeRulesForIvyModules(ivyManager, module.getProject()));
                     updateIntellijModel(module, resolver.getDependencies());
                     reportProblems(module, resolver.getProblems());
                 }

--- a/src/main/java/org/clarent/ivyidea/ResolveForAllModulesAction.java
+++ b/src/main/java/org/clarent/ivyidea/ResolveForAllModulesAction.java
@@ -30,6 +30,7 @@ import org.clarent.ivyidea.intellij.IntellijUtils;
 import org.clarent.ivyidea.intellij.task.IvyIdeaResolveBackgroundTask;
 import org.clarent.ivyidea.ivy.IvyManager;
 import org.clarent.ivyidea.resolve.IntellijDependencyResolver;
+import org.clarent.ivyidea.resolve.ResolveUtil;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -57,7 +58,7 @@ public class ResolveForAllModulesAction extends AbstractResolveAction {
                     getProgressMonitorThread().setIvy(ivyManager.getIvy(module));
                     indicator.setText2("Resolving for module " + module.getName());
                     final IntellijDependencyResolver resolver = new IntellijDependencyResolver(ivyManager);
-                    resolver.resolve(module);
+                    resolver.resolve(module, ResolveUtil.buildExcludeRulesForIvyModules(ivyManager, project));
                     resolvers.add(resolver);
 
                     if (indicator.isCanceled()) {

--- a/src/main/java/org/clarent/ivyidea/intellij/model/LibraryModels.java
+++ b/src/main/java/org/clarent/ivyidea/intellij/model/LibraryModels.java
@@ -16,7 +16,9 @@
 
 package org.clarent.ivyidea.intellij.model;
 
+import com.intellij.openapi.roots.LibraryOrderEntry;
 import com.intellij.openapi.roots.ModifiableRootModel;
+import com.intellij.openapi.roots.OrderEntry;
 import com.intellij.openapi.roots.OrderRootType;
 import com.intellij.openapi.roots.libraries.Library;
 import com.intellij.openapi.roots.libraries.LibraryTable;
@@ -61,11 +63,13 @@ class LibraryModels implements Closeable {
 
     private Library getIvyIdeaLibrary(ModifiableRootModel modifiableRootModel, final String libraryName) {
         final LibraryTable libraryTable = modifiableRootModel.getModuleLibraryTable();
-        final Library library = libraryTable.getLibraryByName(libraryName);
+        Library library = libraryTable.getLibraryByName(libraryName);
         if (library == null) {
             LOGGER.info("Internal library not found for module " + modifiableRootModel.getModule().getModuleFilePath() + ", creating with name " + libraryName + "...");
-            return libraryTable.createLibrary(libraryName);
+            library = libraryTable.createLibrary(libraryName);
         }
+        LibraryOrderEntry libraryOrderEntry = modifiableRootModel.findLibraryOrderEntry(library);
+        libraryOrderEntry.setExported(true);
         return library;
     }
 

--- a/src/main/java/org/clarent/ivyidea/resolve/IntellijDependencyResolver.java
+++ b/src/main/java/org/clarent/ivyidea/resolve/IntellijDependencyResolver.java
@@ -17,6 +17,7 @@
 package org.clarent.ivyidea.resolve;
 
 import com.intellij.openapi.module.Module;
+import org.apache.ivy.core.module.descriptor.ExcludeRule;
 import org.clarent.ivyidea.exception.IvyFileReadException;
 import org.clarent.ivyidea.exception.IvySettingsFileReadException;
 import org.clarent.ivyidea.exception.IvySettingsNotFoundException;
@@ -57,10 +58,11 @@ public class IntellijDependencyResolver {
         return dependencies;
     }
 
-    public void resolve(final Module module) throws IvySettingsNotFoundException, IvyFileReadException, IvySettingsFileReadException {
+    public void resolve(final Module module, List<ExcludeRule> excludeRules) throws IvySettingsNotFoundException, IvyFileReadException, IvySettingsFileReadException {
         this.module = module;
+
         final DependencyResolver dependencyResolver = new DependencyResolver();
-        dependencyResolver.resolve(module, ivyManager);
+        dependencyResolver.resolve(module, ivyManager, excludeRules);
         dependencies = dependencyResolver.getResolvedDependencies();
         problems = dependencyResolver.getResolveProblems();
     }

--- a/src/main/java/org/clarent/ivyidea/resolve/IntellijModuleDependencies.java
+++ b/src/main/java/org/clarent/ivyidea/resolve/IntellijModuleDependencies.java
@@ -26,7 +26,9 @@ import org.clarent.ivyidea.intellij.IntellijUtils;
 import org.clarent.ivyidea.ivy.IvyManager;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.HashMap;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.logging.Logger;
 
@@ -40,7 +42,7 @@ class IntellijModuleDependencies {
 
     private IvyManager ivyManager;
     private Module module;
-    private Map<ModuleId, Module> moduleDependencies = new HashMap<ModuleId, Module>();
+    private Map<ModuleId, Module> moduleDependencies = new LinkedHashMap<ModuleId, Module>();
 
     public IntellijModuleDependencies(Module module, IvyManager ivyManager) throws IvySettingsNotFoundException, IvySettingsFileReadException {
         this.module = module;
@@ -60,13 +62,18 @@ class IntellijModuleDependencies {
         return moduleDependencies.get(moduleId);
     }
 
+    public Collection<Module> getModuleDependencies() {
+        return Collections.unmodifiableCollection(moduleDependencies.values());
+    }
+
     private void fillModuleDependencies() throws IvySettingsNotFoundException, IvySettingsFileReadException {
         final ModuleDescriptor descriptor = ivyManager.getModuleDescriptor(module);
         if (descriptor != null) {
             final DependencyDescriptor[] ivyDependencies = descriptor.getDependencies();
-            for (Module dependencyModule : IntellijUtils.getAllModulesWithIvyIdeaFacet(module.getProject())) {
-                if (!module.equals(dependencyModule)) {
-                    for (DependencyDescriptor ivyDependency : ivyDependencies) {
+            final Module[] dependencyModules = IntellijUtils.getAllModulesWithIvyIdeaFacet(module.getProject());
+            for (DependencyDescriptor ivyDependency : ivyDependencies) {
+                for (Module dependencyModule : dependencyModules) {
+                    if (!module.equals(dependencyModule)) {
                         final ModuleId ivyDependencyId = ivyDependency.getDependencyId();
                         final ModuleId dependencyModuleId = getModuleId(dependencyModule);
                         if (ivyDependencyId.equals(dependencyModuleId)) {
@@ -85,7 +92,7 @@ class IntellijModuleDependencies {
         if (!moduleDependencies.values().contains(module)) {
             final ModuleDescriptor ivyModuleDescriptor = ivyManager.getModuleDescriptor(module);
             if (ivyModuleDescriptor != null) {
-                moduleDependencies.put(ivyModuleDescriptor.getModuleRevisionId().getModuleId(), module);
+                return ivyModuleDescriptor.getModuleRevisionId().getModuleId();
             }
 
         }

--- a/src/main/java/org/clarent/ivyidea/resolve/ResolveUtil.java
+++ b/src/main/java/org/clarent/ivyidea/resolve/ResolveUtil.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2010 Guy Mahieu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.clarent.ivyidea.resolve;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
+import org.apache.ivy.core.module.descriptor.DefaultExcludeRule;
+import org.apache.ivy.core.module.descriptor.ExcludeRule;
+import org.apache.ivy.core.module.descriptor.ModuleDescriptor;
+import org.apache.ivy.core.module.id.ArtifactId;
+import org.apache.ivy.core.module.id.ModuleId;
+import org.apache.ivy.plugins.matcher.GlobPatternMatcher;
+import org.apache.ivy.plugins.matcher.PatternMatcher;
+import org.clarent.ivyidea.exception.IvySettingsFileReadException;
+import org.clarent.ivyidea.exception.IvySettingsNotFoundException;
+import org.clarent.ivyidea.intellij.IntellijUtils;
+import org.clarent.ivyidea.ivy.IvyManager;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ResolveUtil {
+    public static List<ExcludeRule> buildExcludeRulesForIvyModules(IvyManager ivyManager, Project project) throws IvySettingsFileReadException, IvySettingsNotFoundException {
+        return buildExcludeRulesForIvyModules(ivyManager, IntellijUtils.getAllModulesWithIvyIdeaFacet(project));
+    }
+
+    public static List<ExcludeRule> buildExcludeRulesForIvyModules(IvyManager ivyManager, Module... ivyModules) throws IvySettingsFileReadException, IvySettingsNotFoundException {
+        List<ExcludeRule> excludeRules = new ArrayList<ExcludeRule>();
+
+        for (final Module ivyModule : ivyModules) {
+            ModuleDescriptor moduleDescriptor = ivyManager.getModuleDescriptor(ivyModule);
+
+            ModuleId moduleId = moduleDescriptor.getModuleRevisionId().getModuleId();
+
+            ArtifactId aid = new ArtifactId(moduleId, PatternMatcher.ANY_EXPRESSION, PatternMatcher.ANY_EXPRESSION, PatternMatcher.ANY_EXPRESSION);
+            DefaultExcludeRule rule = new DefaultExcludeRule(aid, GlobPatternMatcher.INSTANCE, null);
+
+            for (String configurationName : moduleDescriptor.getConfigurationsNames()) {
+                rule.addConfiguration(configurationName);
+            }
+
+            excludeRules.add(rule);
+        }
+        return excludeRules;
+    }
+}


### PR DESCRIPTION
…d in the same project. Instead include in the IvyIDEA library only direct non-module dependencies and export the library.

I have a project with ~100 modules with interdependencies. Resolving all the modules in this project using 1.0.13 takes ~10 minutes even if no new artifacts are downloaded. From what I can tell the problem is that each time one of the modules appears in the dependency list of another module it's resolved together with the modules it depends on.

The changes contained in this PR add ivy exclude rules for the modules present in idea and instead of resolving them transitively and adding all the transitive dependencies to the IvyIDEA library will only resolve direct dependencies and export the IvyIDEA library of each module.

In addition to this it includes changes to keep the order of the internal dependencies consistent with the one in ivy.xml.