### PR TITLE
Added option in settings to avoid internal modules dependencies resolving

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -16,7 +16,7 @@
 
 <project name="IvyIDEA" default="bundle" basedir=".">
 
-    <property name="ivyidea.version" value="1.0.14"/>
+    <property name="ivyidea.version" value="1.0.15-jberta93"/>
 
     <property name="ivyidea.sourcedir" value="src/main/java"/>
     <property name="ivyidea.resourcedir" value="src/main/resources"/>
@@ -25,6 +25,7 @@
     <property name="ivyidea.libdir" value="lib"/>
     
     <property environment="env" />
+    <property name="env.IDEA_HOME" value="/Applications/IntelliJ IDEA.app/Contents"/>
     <property name="idea.home" value="${env.IDEA_HOME}" />
 
     <fail message="Environment variable IDEA_HOME was not set!">
@@ -49,29 +50,35 @@
         <delete dir="build" />
     </target>
 
+
+    <path id="clspath">
+
+        <fileset dir="${idea.home}/lib">
+            <include name="*.jar"/>
+
+        </fileset>
+
+        <fileset dir="${idea.home}/plugins/java/lib">
+            <include name="*.jar"/>
+        </fileset>
+        <fileset dir="${ivyidea.libdir}">
+            <include name="ivy-2.4.0.jar"/>
+        </fileset>
+    </path>
+
+
     <target name="jar">
         <mkdir dir="build" />
         <mkdir dir="${ivyidea.builddir}" />
+
         
         <javac2 srcdir="${ivyidea.sourcedir}"
                 destdir="${ivyidea.builddir}"
-                source="1.6"
-                target="1.6"
+                source="1.8"
+                target="1.8"
                 includeantruntime="false"
                 debug="true">
-            <classpath>
-                <!-- intelliJ API -->
-                <pathelement location="${idea.home}/lib/annotations.jar" />
-                <pathelement location="${idea.home}/lib/extensions.jar" />
-                <pathelement location="${idea.home}/lib/forms_rt.jar" />
-                <pathelement location="${idea.home}/lib/jdom.jar" />
-                <pathelement location="${idea.home}/lib/openapi.jar" />
-                <pathelement location="${idea.home}/lib/util.jar" />
-				<pathelement location="${idea.home}/lib/idea.jar" />
-            
-                <!-- Ivy -->
-                <pathelement location="${ivyidea.libdir}/ivy-2.4.0.jar" />
-            </classpath>
+            <classpath refid="clspath"></classpath>
         </javac2>
         
         <jar file="build/ivyidea-${ivyidea.version}.jar">

--- a/src/main/java/META-INF/plugin.xml
+++ b/src/main/java/META-INF/plugin.xml
@@ -16,6 +16,10 @@
     </description>
     <change-notes><![CDATA[
         <p>
+            <strong>1.0.15-jberta93</strong>
+            <ul>
+                <li>Added checkbox "Avoid internal modules dependecies resolving" to force IvyIDEA to resolve dependecies only through the ivy.xml ignoring internal modules</li>
+            </ul>
             <strong>1.0.14</strong>
             <ul>
                 <li>When trying to resolve dependencies without an Ivy settings file, an IllegalArgumentException 
@@ -118,7 +122,7 @@
             </ul>
         </p>]]>
     </change-notes>
-    <version>1.0.14</version>
+    <version>1.0.15-jberta93</version>
     <vendor email="guy.mahieu@gmail.com" url="http://www.clarent.org" logo="/ivyidea16.png">Guy Mahieu</vendor>
     <idea-version since-build="3000"/>
     <application-components>

--- a/src/main/java/org/clarent/ivyidea/config/IvyIdeaConfigHelper.java
+++ b/src/main/java/org/clarent/ivyidea/config/IvyIdeaConfigHelper.java
@@ -131,6 +131,10 @@ public class IvyIdeaConfigHelper {
         return getProjectConfig(project).isAlwaysAttachJavadocs();
     }
 
+    public static boolean avoidInternalModuleDependeciesResolving(final Project project){
+        return getProjectConfig(project).isAvoidInternalModuleDependenciesResolving();
+    }
+
     @NotNull
     private static IvyIdeaProjectSettings getProjectConfig(Project project) {
         IvyIdeaProjectComponent component = project.getComponent(IvyIdeaProjectComponent.class);

--- a/src/main/java/org/clarent/ivyidea/config/model/IvyIdeaProjectSettings.java
+++ b/src/main/java/org/clarent/ivyidea/config/model/IvyIdeaProjectSettings.java
@@ -34,7 +34,10 @@ public class IvyIdeaProjectSettings {
     private boolean alwaysAttachJavadocs = true;
     private boolean libraryNameIncludesModule = false;
     private boolean libraryNameIncludesConfiguration = false;
+    private boolean avoidInternalModuleDependenciesResolving = false;
     private String ivyLogLevelThreshold = IvyLogLevel.None.name();
+
+
     private ArtifactTypeSettings artifactTypeSettings = new ArtifactTypeSettings();
 
     private PropertiesSettings propertiesSettings = new PropertiesSettings();
@@ -125,6 +128,14 @@ public class IvyIdeaProjectSettings {
 
     public void setLibraryNameIncludesConfiguration(final boolean libraryNameIncludesConfiguration) {
         this.libraryNameIncludesConfiguration = libraryNameIncludesConfiguration;
+    }
+
+    public boolean isAvoidInternalModuleDependenciesResolving() {
+        return avoidInternalModuleDependenciesResolving;
+    }
+
+    public void setAvoidInternalModuleDependenciesResolving(boolean avoidInternalModuleDependenciesResolving) {
+        this.avoidInternalModuleDependenciesResolving = avoidInternalModuleDependenciesResolving;
     }
 
     public String getIvyLogLevelThreshold() {

--- a/src/main/java/org/clarent/ivyidea/intellij/IvyIdeaProjectComponent.java
+++ b/src/main/java/org/clarent/ivyidea/intellij/IvyIdeaProjectComponent.java
@@ -38,7 +38,7 @@ import javax.swing.*;
 
 @State(
         name = IvyIdeaProjectComponent.COMPONENT_NAME,
-        storages = {@Storage(id = "IvyIDEA", file = "$PROJECT_FILE$")}
+        storages = {@Storage(file = "$PROJECT_FILE$")}
 )
 public class IvyIdeaProjectComponent implements ProjectComponent, PersistentStateComponent<IvyIdeaProjectSettings> {
 

--- a/src/main/java/org/clarent/ivyidea/intellij/ui/IvyIdeaProjectSettingsPanel.form
+++ b/src/main/java/org/clarent/ivyidea/intellij/ui/IvyIdeaProjectSettingsPanel.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="projectSettingsPanel" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="829" height="600"/>
+      <xy x="20" y="20" width="829" height="627"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -290,6 +290,7 @@
                     </constraints>
                     <properties>
                       <text value="Avoid internal modules dependecies resolving"/>
+                      <toolTipText value="Force IvyIDEA to resolve dependecies only through the ivy.xml ignoring internal modules"/>
                     </properties>
                   </component>
                 </children>

--- a/src/main/java/org/clarent/ivyidea/intellij/ui/IvyIdeaProjectSettingsPanel.form
+++ b/src/main/java/org/clarent/ivyidea/intellij/ui/IvyIdeaProjectSettingsPanel.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="projectSettingsPanel" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="749" height="564"/>
+      <xy x="20" y="20" width="829" height="600"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -208,7 +208,9 @@
                         <preferred-size width="150" height="-1"/>
                       </grid>
                     </constraints>
-                    <properties/>
+                    <properties>
+                      <toolTipText value="Force IvyIDEA to resolve dependecies only through the ivy.xml ignoring internal module dependecies"/>
+                    </properties>
                   </component>
                 </children>
               </grid>
@@ -219,7 +221,7 @@
                   </grid>
                 </constraints>
               </vspacer>
-              <grid id="ee84a" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+              <grid id="ee84a" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                 <margin top="0" left="0" bottom="0" right="0"/>
                 <constraints>
                   <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -280,6 +282,14 @@
                       <selected value="true"/>
                       <text value="Always attach javadoc artifacts"/>
                       <toolTipText value="Always attach javadoc artifacts to the library, even if they aren't selected by an Ivy configuration"/>
+                    </properties>
+                  </component>
+                  <component id="39b4b" class="javax.swing.JCheckBox" binding="avoidInternalModuleDependeciesResolving">
+                    <constraints>
+                      <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text value="Avoid internal modules dependecies resolving"/>
                     </properties>
                   </component>
                 </children>

--- a/src/main/java/org/clarent/ivyidea/intellij/ui/IvyIdeaProjectSettingsPanel.java
+++ b/src/main/java/org/clarent/ivyidea/intellij/ui/IvyIdeaProjectSettingsPanel.java
@@ -65,6 +65,7 @@ public class IvyIdeaProjectSettingsPanel {
     private JCheckBox chkBackground;
     private JCheckBox autoAttachSources;
     private JCheckBox autoAttachJavadocs;
+    private JCheckBox avoidInternalModuleDependeciesResolving;
     private JPanel pnlIvyFiles;
     private JPanel pnlArtefactTypes;
     private IvyIdeaProjectSettings internalState;
@@ -127,6 +128,7 @@ public class IvyIdeaProjectSettingsPanel {
         internalState.setAlwaysAttachSources(autoAttachSources.isSelected());
         internalState.setAlwaysAttachJavadocs(autoAttachJavadocs.isSelected());
         internalState.setUseCustomIvySettings(useYourOwnIvySettingsRadioButton.isSelected());
+        internalState.setAvoidInternalModuleDependenciesResolving(avoidInternalModuleDependeciesResolving.isSelected());
         final PropertiesSettings propertiesSettings = new PropertiesSettings();
         propertiesSettings.setPropertyFiles(getPropertiesFiles());
         internalState.setPropertiesSettings(propertiesSettings);
@@ -152,6 +154,7 @@ public class IvyIdeaProjectSettingsPanel {
         autoAttachSources.setSelected(config.isAlwaysAttachSources());
         autoAttachJavadocs.setSelected(config.isAlwaysAttachJavadocs());
         useYourOwnIvySettingsRadioButton.setSelected(config.isUseCustomIvySettings());
+        avoidInternalModuleDependeciesResolving.setSelected(config.isAvoidInternalModuleDependenciesResolving());
         setPropertiesFiles(config.getPropertiesSettings().getPropertyFiles());
         includeModuleNameCheckBox.setSelected(config.isLibraryNameIncludesModule());
         includeConfigurationNameCheckBox.setSelected(config.isLibraryNameIncludesConfiguration());

--- a/src/main/java/org/clarent/ivyidea/resolve/DependencyResolver.java
+++ b/src/main/java/org/clarent/ivyidea/resolve/DependencyResolver.java
@@ -102,7 +102,9 @@ class DependencyResolver {
             @SuppressWarnings({"unchecked"})
             Set<ModuleRevisionId> dependencies = (Set<ModuleRevisionId>) configurationReport.getModuleRevisionIds();
             for (ModuleRevisionId dependency : dependencies) {
-                if (moduleDependencies.isInternalIntellijModuleDependency(dependency.getModuleId())) {
+                // Added check to configuration to avoid internal module deps resolving in case user has checked the checkbox in config
+                boolean isAvoidInternalModuleDepsResolving = IvyIdeaConfigHelper.avoidInternalModuleDependeciesResolving(moduleDependencies.getModule().getProject());
+                if (moduleDependencies.isInternalIntellijModuleDependency(dependency.getModuleId()) && !isAvoidInternalModuleDepsResolving) {
                     resolvedDependencies.add(new InternalDependency(moduleDependencies.getModuleDependency(dependency.getModuleId())));
                 } else {
                     final Project project = moduleDependencies.getModule().getProject();


### PR DESCRIPTION
Hi @maartenc,
I have added the possibility in settings to disable the internal modules dependencies resolving.
By default, the options is set to false and IvyIDEA continues to resolve internal modules ignoring the ivy.xml if in project there's a module with the same name.
If user checks the options IvyIDEA resolve all the dependencies using ivy.xml ignoring the internal modules.

I see that the feature has been requested multiple times in multiple issues (#158) and i add this feature and tested in IJ 2019.3

I hope to see soon this feature integrated in the project and available in IntellJ Marketplace because is very useful when you work with a lot of modules.

